### PR TITLE
Redesign site (clean, modern) + add side projects and career/education

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,11 +29,11 @@ const jetbrainsMono = JetBrains_Mono({
 })
 
 export const metadata = {
-  title: "Fatma Ali | Senior Software Engineer (Microsoft M365 AI)",
-  description: "Senior Software Engineer at Microsoft (M365 AI Experiences) building AI-powered productivity and collaboration experiences with scalable systems and human-centered UX.",
+  title: "Fatma Ali | Senior Full-Stack Engineer at Microsoft",
+  description: "Senior full-stack engineer at Microsoft building AI-native Microsoft 365 Copilot and agent experiences end to end — React, TypeScript, C#/.NET. 7+ years shipping product, from database to pixel.",
   metadataBase: new URL('https://fatmaali.dev'),
   keywords: [
-    'Senior Software Engineer','Microsoft','M365 AI','AI Productivity','AI Collaboration','React','TypeScript','Next.js','Web Performance','Scalable Systems','Cloud Architecture','User Experience','Portfolio'
+    'Senior Full-Stack Engineer','Full Stack Engineer','Microsoft','M365 Copilot','AI Engineer','LLM','React','TypeScript','C#','.NET','Next.js','GraphQL','PostgreSQL','Software Engineer','Portfolio'
   ],
   category: 'technology',
   authors: [{ name: 'Fatma Ali', url: 'https://fatmaali.dev' }],
@@ -54,15 +54,15 @@ export const metadata = {
     type: 'website',
     locale: 'en_US',
     url: 'https://fatmaali.dev',
-    title: 'Fatma Ali | Senior Software Engineer (Microsoft M365 AI)',
-    description: 'AI-powered productivity & collaboration experiences. React, TypeScript, Next.js, scalable systems.',
+    title: 'Fatma Ali | Senior Full-Stack Engineer at Microsoft',
+    description: 'AI-native, full-stack engineering — M365 Copilot & agent experiences, end to end. React, TypeScript, C#/.NET.',
     siteName: 'Fatma Ali Portfolio',
     images: [
       {
         url: '/images/headshot.JPG',
         width: 1200,
         height: 630,
-        alt: 'Fatma Ali - Senior Software Engineer',
+        alt: 'Fatma Ali - Senior Full-Stack Engineer',
       },
     ],
   },
@@ -70,8 +70,8 @@ export const metadata = {
     card: 'summary_large_image',
     site: '@_fatmali',
     creator: '@_fatmali',
-    title: 'Fatma Ali | Senior Software Engineer (Microsoft M365 AI)',
-    description: 'AI-powered productivity & collaboration engineering. React • TypeScript • Next.js • Scalable systems.',
+    title: 'Fatma Ali | Senior Full-Stack Engineer at Microsoft',
+    description: 'AI-native, full-stack engineering — M365 Copilot & agent experiences, end to end. React • TypeScript • C#/.NET.',
     images: ['/images/headshot.JPG']
   },
   alternates: {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,8 +29,8 @@ const jetbrainsMono = JetBrains_Mono({
 })
 
 export const metadata = {
-  title: "Fatma Ali | Senior Full-Stack Engineer at Microsoft",
-  description: "Senior full-stack engineer at Microsoft building AI-native Microsoft 365 Copilot and agent experiences end to end — React, TypeScript, C#/.NET. 7+ years shipping product, from database to pixel.",
+  title: "Fatma Ali | Senior Software Engineer, Full Stack — Microsoft",
+  description: "Senior Software Engineer (Full Stack) at Microsoft building AI-native Microsoft 365 Copilot and agent experiences end to end — React, TypeScript, C#/.NET. 7+ years shipping product, from database to pixel.",
   metadataBase: new URL('https://fatmaali.dev'),
   keywords: [
     'Senior Full-Stack Engineer','Full Stack Engineer','Microsoft','M365 Copilot','AI Engineer','LLM','React','TypeScript','C#','.NET','Next.js','GraphQL','PostgreSQL','Software Engineer','Portfolio'
@@ -54,7 +54,7 @@ export const metadata = {
     type: 'website',
     locale: 'en_US',
     url: 'https://fatmaali.dev',
-    title: 'Fatma Ali | Senior Full-Stack Engineer at Microsoft',
+    title: 'Fatma Ali | Senior Software Engineer, Full Stack — Microsoft',
     description: 'AI-native, full-stack engineering — M365 Copilot & agent experiences, end to end. React, TypeScript, C#/.NET.',
     siteName: 'Fatma Ali Portfolio',
     images: [
@@ -62,7 +62,7 @@ export const metadata = {
         url: '/images/headshot.JPG',
         width: 1200,
         height: 630,
-        alt: 'Fatma Ali - Senior Full-Stack Engineer',
+        alt: 'Fatma Ali - Senior Software Engineer, Full Stack',
       },
     ],
   },
@@ -70,7 +70,7 @@ export const metadata = {
     card: 'summary_large_image',
     site: '@_fatmali',
     creator: '@_fatmali',
-    title: 'Fatma Ali | Senior Full-Stack Engineer at Microsoft',
+    title: 'Fatma Ali | Senior Software Engineer, Full Stack — Microsoft',
     description: 'AI-native, full-stack engineering — M365 Copilot & agent experiences, end to end. React • TypeScript • C#/.NET.',
     images: ['/images/headshot.JPG']
   },

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -71,7 +71,7 @@ export default async function Image() {
           zIndex: 10
         }}>
           <div style={{ fontSize: 72, fontWeight: 'bold', marginBottom: 10 }}>Fatma Ali</div>
-          <div style={{ fontSize: 36, fontWeight: 'normal', color: '#d1d5db' }}>Senior Full-Stack Engineer · Microsoft</div>
+          <div style={{ fontSize: 36, fontWeight: 'normal', color: '#d1d5db' }}>Senior Software Engineer, Full Stack · Microsoft</div>
           <div style={{
             display: 'flex',
             marginTop: 20,

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -71,7 +71,7 @@ export default async function Image() {
           zIndex: 10
         }}>
           <div style={{ fontSize: 72, fontWeight: 'bold', marginBottom: 10 }}>Fatma Ali</div>
-          <div style={{ fontSize: 36, fontWeight: 'normal', color: '#d1d5db' }}>Senior Software Engineer</div>
+          <div style={{ fontSize: 36, fontWeight: 'normal', color: '#d1d5db' }}>Senior Full-Stack Engineer · Microsoft</div>
           <div style={{
             display: 'flex',
             marginTop: 20,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,13 +27,14 @@ export default async function RootPage() {
 	return (
 		<>
 			<HeroSection />
+			<AboutSection ctaHref="/contact" />
 			<ProjectsSection />
 
 			{/* Latest writing */}
 			<section className="py-24 md:py-32 bg-surface">
 				<div className="container mx-auto px-4 sm:px-6 lg:px-8">
 					<div className="max-w-2xl mb-16">
-						<span className="mono-label">005 — Writing</span>
+						<span className="mono-label">003 — Writing</span>
 						<h2 className="mt-4 text-3xl md:text-5xl font-bold tracking-tight">From the blog.</h2>
 						<p className="mt-4 text-muted-foreground leading-relaxed">
 							Notes on software development, React, Next.js, AI-assisted
@@ -43,8 +44,6 @@ export default async function RootPage() {
 					<BlogListClient posts={posts} />
 				</div>
 			</section>
-
-			<AboutSection ctaHref="/contact" />
 		</>
 	);
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,13 +28,12 @@ export default async function RootPage() {
 		<>
 			<HeroSection />
 			<AboutSection ctaHref="/contact" />
-			<ProjectsSection />
 
 			{/* Latest writing */}
-			<section className="py-24 md:py-32 bg-surface">
+			<section className="py-24 md:py-32">
 				<div className="container mx-auto px-4 sm:px-6 lg:px-8">
 					<div className="max-w-2xl mb-16">
-						<span className="mono-label">003 — Writing</span>
+						<span className="mono-label">002 — Writing</span>
 						<h2 className="mt-4 text-3xl md:text-5xl font-bold tracking-tight">From the blog.</h2>
 						<p className="mt-4 text-muted-foreground leading-relaxed">
 							Notes on software development, React, Next.js, AI-assisted
@@ -44,6 +43,8 @@ export default async function RootPage() {
 					<BlogListClient posts={posts} />
 				</div>
 			</section>
+
+			<ProjectsSection index="003" />
 		</>
 	);
 }

--- a/src/components/sections/about-section.tsx
+++ b/src/components/sections/about-section.tsx
@@ -6,24 +6,40 @@ interface AboutSectionProps {
   ctaHref?: string; // default '#contact' for backward compatibility
 }
 
-const facts = [
+const experience = [
   {
-    label: "At work",
-    title: "Senior Engineer · Microsoft",
+    period: "May 2021 — Present",
+    role: "Senior Software Engineer",
+    company: "Microsoft",
     description:
-      "Designing and building the front ends and platform behind 70+ Microsoft 365 Copilot and agent experiences — React and TypeScript on top of C#/.NET services used by enterprises globally.",
+      "Design and build the interfaces and platform behind 70+ first-party Microsoft 365 Copilot and agent experiences — React and TypeScript front ends on top of C#/.NET services used by enterprises globally. Ship features end to end and help set product direction.",
   },
   {
-    label: "Studying",
-    title: "M.S. CS · Georgia Tech",
+    period: "Jul 2020 — Apr 2021",
+    role: "Software Engineer",
+    company: "Antara Health",
     description:
-      "OMSCS with an Artificial Intelligence specialization and graduate HCI coursework in interaction design and usability evaluation.",
+      "Built full-stack features for a chronic-care health navigation platform — Django services and REST APIs on PostgreSQL with responsive React front ends — improving patient access efficiency by ~30%.",
   },
   {
-    label: "Craft",
-    title: "Full-stack, leaning front end",
+    period: "Sep 2018 — Feb 2020",
+    role: "Software Engineer",
+    company: "AMPATH",
     description:
-      "Seven-plus years shipping user-facing product end to end — React, TypeScript, Relay, and GraphQL up front; C#/.NET, Python, and Postgres behind it.",
+      "Worked across front end and back end on Kenya's first point-of-care medical system (OpenMRS — Angular + MySQL), supporting care for 200,000+ HIV patients and the move from paper to digital records.",
+  },
+];
+
+const education = [
+  {
+    period: "Aug 2025 — Present",
+    school: "Georgia Institute of Technology",
+    detail: "M.S. Computer Science (OMSCS) · Artificial Intelligence specialization",
+  },
+  {
+    period: "2014 — 2017",
+    school: "University of Eldoret",
+    detail: "B.Sc. Information Technology",
   },
 ];
 
@@ -31,57 +47,101 @@ export function AboutSection({ ctaHref = "#contact" }: AboutSectionProps) {
   return (
     <section className="py-24 md:py-32 relative bg-surface" id="about">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+        {/* Lead */}
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: "-100px" }}
+          transition={{ duration: 0.6 }}
+          className="max-w-2xl mb-16 md:mb-20"
+        >
+          <span className="mono-label">001 — Background</span>
+          <h2 className="mt-4 text-3xl md:text-5xl font-bold tracking-tight leading-tight">
+            I build across the whole stack.
+          </h2>
+          <p className="mt-6 text-muted-foreground leading-relaxed">
+            Seven-plus years shipping user-facing product from database to
+            pixel — today that&apos;s AI-powered Copilot experiences at
+            Microsoft; before that, health platforms serving hundreds of
+            thousands of patients across Kenya. I like owning a feature end to
+            end and sweating both the system design and the last 5% of UX.
+          </p>
+        </motion.div>
+
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-12 lg:gap-16">
-          {/* Lead */}
+          {/* Experience */}
           <motion.div
             initial={{ opacity: 0, y: 16 }}
             whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, margin: "-100px" }}
+            viewport={{ once: true, margin: "-60px" }}
             transition={{ duration: 0.6 }}
-            className="lg:col-span-5"
+            className="lg:col-span-8"
           >
-            <span className="mono-label">001 — About</span>
-            <h2 className="mt-4 text-3xl md:text-4xl font-bold tracking-tight leading-tight">
-              Engineer by day, relentless tinkerer the rest of the time.
-            </h2>
-            <p className="mt-6 text-muted-foreground leading-relaxed">
-              I care about the seam where thoughtful design meets solid
-              engineering — where a product feels effortless because the system
-              underneath it is genuinely well built. Most of what I make starts
-              as a small problem in my own day.
-            </p>
-          </motion.div>
-
-          {/* Facts */}
-          <div className="lg:col-span-7 lg:pt-2">
-            <div className="divide-y divide-border border-y border-border">
-              {facts.map((fact, i) => (
-                <motion.div
-                  key={fact.title}
-                  initial={{ opacity: 0, y: 16 }}
-                  whileInView={{ opacity: 1, y: 0 }}
-                  viewport={{ once: true, margin: "-50px" }}
-                  transition={{ duration: 0.5, delay: i * 0.08 }}
-                  className="py-6 grid grid-cols-1 sm:grid-cols-[9rem_1fr] gap-2 sm:gap-6"
-                >
-                  <span className="mono-label pt-1">{fact.label}</span>
-                  <div>
-                    <h3 className="font-semibold text-lg">{fact.title}</h3>
-                    <p className="mt-1 text-sm text-muted-foreground leading-relaxed">
-                      {fact.description}
-                    </p>
-                  </div>
-                </motion.div>
-              ))}
+            <div className="flex items-center gap-3 mb-6">
+              <span className="mono-label">Experience</span>
+              <span className="h-px flex-1 bg-border" />
             </div>
 
-            <motion.div
-              initial={{ opacity: 0, y: 12 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true, margin: "-50px" }}
-              transition={{ duration: 0.6, delay: 0.2 }}
-              className="mt-10 flex items-center gap-4 flex-wrap"
-            >
+            <ol className="relative">
+              {experience.map((job, i) => (
+                <motion.li
+                  key={job.company}
+                  initial={{ opacity: 0, y: 16 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  viewport={{ once: true, margin: "-40px" }}
+                  transition={{ duration: 0.5, delay: i * 0.08 }}
+                  className="grid grid-cols-1 sm:grid-cols-[11rem_1fr] gap-2 sm:gap-6 py-6 border-t border-border first:border-t-0"
+                >
+                  <span className="font-mono text-xs text-muted-foreground pt-1">
+                    {job.period}
+                  </span>
+                  <div>
+                    <h3 className="text-lg font-semibold">
+                      {job.role}{" "}
+                      <span className="text-accent">· {job.company}</span>
+                    </h3>
+                    <p className="mt-1.5 text-sm text-muted-foreground leading-relaxed">
+                      {job.description}
+                    </p>
+                  </div>
+                </motion.li>
+              ))}
+            </ol>
+          </motion.div>
+
+          {/* Education */}
+          <motion.div
+            initial={{ opacity: 0, y: 16 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, margin: "-60px" }}
+            transition={{ duration: 0.6, delay: 0.1 }}
+            className="lg:col-span-4"
+          >
+            <div className="flex items-center gap-3 mb-6">
+              <span className="mono-label">Education</span>
+              <span className="h-px flex-1 bg-border" />
+            </div>
+
+            <ul className="space-y-6">
+              {education.map((edu) => (
+                <li
+                  key={edu.school}
+                  className="border-l-2 border-accent/40 pl-4"
+                >
+                  <span className="font-mono text-xs text-muted-foreground">
+                    {edu.period}
+                  </span>
+                  <h3 className="mt-1 font-semibold leading-snug">
+                    {edu.school}
+                  </h3>
+                  <p className="mt-1 text-sm text-muted-foreground leading-relaxed">
+                    {edu.detail}
+                  </p>
+                </li>
+              ))}
+            </ul>
+
+            <div className="mt-10 flex flex-col items-start gap-4">
               <a
                 href={ctaHref}
                 className="inline-flex items-center gap-2 px-6 py-3 rounded-full bg-foreground text-background font-medium hover:bg-accent hover:text-accent-foreground transition-colors"
@@ -109,8 +169,8 @@ export function AboutSection({ ctaHref = "#contact" }: AboutSectionProps) {
               >
                 Download résumé →
               </a>
-            </motion.div>
-          </div>
+            </div>
+          </motion.div>
         </div>
       </div>
     </section>

--- a/src/components/sections/about-section.tsx
+++ b/src/components/sections/about-section.tsx
@@ -43,6 +43,13 @@ const education = [
   },
 ];
 
+const stats = [
+  { value: "7+", label: "Years shipping product" },
+  { value: "70+", label: "Copilot & agent experiences" },
+  { value: "200K+", label: "Patients served" },
+  { value: "~30%", label: "Efficiency gained" },
+];
+
 export function AboutSection({ ctaHref = "#contact" }: AboutSectionProps) {
   return (
     <section className="py-24 md:py-32 relative bg-surface" id="about">
@@ -57,15 +64,35 @@ export function AboutSection({ ctaHref = "#contact" }: AboutSectionProps) {
         >
           <span className="mono-label">001 — Background</span>
           <h2 className="mt-4 text-3xl md:text-5xl font-bold tracking-tight leading-tight">
-            I build across the whole stack.
+            An AI-native, full-stack engineer.
           </h2>
           <p className="mt-6 text-muted-foreground leading-relaxed">
             Seven-plus years shipping user-facing product from database to
-            pixel — today that&apos;s AI-powered Copilot experiences at
-            Microsoft; before that, health platforms serving hundreds of
-            thousands of patients across Kenya. I like owning a feature end to
-            end and sweating both the system design and the last 5% of UX.
+            pixel. Today I build AI-native products at Microsoft — the platform
+            behind 70+ Microsoft 365 Copilot and agent experiences — and work
+            AI-first, with agentic coding tools in my daily loop. Before that,
+            health platforms serving hundreds of thousands of patients across
+            Kenya. I like owning a feature end to end and sweating both the
+            system design and the last 5% of UX.
           </p>
+        </motion.div>
+
+        {/* Impact at a glance */}
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: "-60px" }}
+          transition={{ duration: 0.6, delay: 0.05 }}
+          className="grid grid-cols-2 md:grid-cols-4 gap-px bg-border border border-border rounded-2xl overflow-hidden mb-16 md:mb-20"
+        >
+          {stats.map((stat) => (
+            <div key={stat.label} className="bg-card p-6 md:p-7">
+              <div className="font-display text-3xl md:text-4xl font-bold tracking-tight">
+                {stat.value}
+              </div>
+              <div className="mono-label mt-2 leading-snug">{stat.label}</div>
+            </div>
+          ))}
         </motion.div>
 
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-12 lg:gap-16">

--- a/src/components/sections/hero-section.tsx
+++ b/src/components/sections/hero-section.tsx
@@ -23,7 +23,7 @@ export function HeroSection() {
           >
             <span className="mono-label">Nairobi · Kenya</span>
             <span className="h-px w-8 bg-border" />
-            <span className="mono-label">Senior Software Engineer</span>
+            <span className="mono-label">Senior Full-Stack Engineer</span>
           </motion.div>
 
           {/* Thesis headline */}
@@ -49,9 +49,10 @@ export function HeroSection() {
           >
             I&apos;m{" "}
             <span className="text-foreground font-medium">Fatma Ali</span> — a
-            senior software engineer at Microsoft building the front ends behind
-            70+ Microsoft 365 Copilot and agent experiences. Full-stack for 7+
-            years, and a perpetual builder of small, useful tools. Bollywood
+            senior full-stack engineer at Microsoft, shipping 70+ Microsoft 365
+            Copilot and agent experiences end to end: from React and TypeScript
+            interfaces to the C#/.NET services behind them. Seven-plus years
+            building product, and a perpetual builder of small tools. Bollywood
             dancer when the tests pass.
           </motion.p>
 

--- a/src/components/sections/hero-section.tsx
+++ b/src/components/sections/hero-section.tsx
@@ -23,7 +23,7 @@ export function HeroSection() {
           >
             <span className="mono-label">Nairobi · Kenya</span>
             <span className="h-px w-8 bg-border" />
-            <span className="mono-label">Senior Full-Stack Engineer</span>
+            <span className="mono-label">Senior Software Engineer, Full Stack</span>
           </motion.div>
 
           {/* Thesis headline */}
@@ -49,7 +49,7 @@ export function HeroSection() {
           >
             I&apos;m{" "}
             <span className="text-foreground font-medium">Fatma Ali</span> — a
-            senior full-stack engineer at Microsoft, shipping 70+ Microsoft 365
+            senior software engineer at Microsoft, shipping 70+ Microsoft 365
             Copilot and agent experiences end to end: from React and TypeScript
             interfaces to the C#/.NET services behind them. Seven-plus years
             building product, and a perpetual builder of small tools. Bollywood

--- a/src/components/sections/projects-section.tsx
+++ b/src/components/sections/projects-section.tsx
@@ -71,7 +71,7 @@ const statusStyles: Record<Project["status"], string> = {
   Building: "text-muted-foreground",
 };
 
-export function ProjectsSection() {
+export function ProjectsSection({ index = "002" }: { index?: string }) {
   return (
     <section id="projects" className="py-24 md:py-32 relative">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
@@ -83,7 +83,7 @@ export function ProjectsSection() {
           transition={{ duration: 0.6 }}
           className="max-w-2xl mb-16 md:mb-20"
         >
-          <span className="mono-label">002 — Selected builds</span>
+          <span className="mono-label">{index} — Selected builds</span>
           <h2 className="mt-4 text-3xl md:text-5xl font-bold tracking-tight">
             Things I&apos;ve been vibecoding.
           </h2>


### PR DESCRIPTION
## Summary

A full visual redesign of the personal site around a distinct **"engineering field notes"** system, plus new content: the vibecoded side projects, a career timeline, and an education section — with all copy reconciled against the résumé.

### Design system
- Warm **paper + ink** palette with a single **clay/terracotta** accent, in full light + dark.
- Type pairing: **Bricolage Grotesque** (display) · **Inter** (body) · **JetBrains Mono** (index labels).
- Signature detail: monospace section index labels (`001 — Background`, `002 — Writing`…), status ticks, hairline dividers, and a blinking clay caret in the hero. Restrained, intentional motion.
- Removed the old sticky-note motif and dead components (`StickyNote`, `geometric-shapes`).

### Fixes the color system (real bug)
The Tailwind color tokens were wrapped in `hsl()` around hex values **and** the JS config wasn't loaded by Tailwind v4 (no `@config`), so `bg-background`, `bg-muted`, and `dark:` variants were largely no-ops. Rebuilt the idiomatic v4 way — `@theme inline` + `@custom-variant dark` — so surface colors and dark mode actually resolve.

### New content
- **Side projects** as a "Selected builds" catalogue: **Herd**, **The London Journal**, **What To Eat**, and **FocusMode**, each with tech tags, status, and links.
- **Career timeline** (Microsoft → Antara Health → AMPATH) and an **Education** block (Georgia Tech OMSCS · AI, University of Eldoret).
- **Impact stat strip**: 7+ yrs · 70+ Copilot & agent experiences · 200K+ patients served · ~30% efficiency.

### Copy & positioning (from résumé)
- Role presented as **"Senior Software Engineer, Full Stack"** (the actual Microsoft title); replaced stale "Frontend Engineer" language.
- **AI-native, full-stack** framing; Georgia Tech specialization corrected to **Artificial Intelligence** (not ML); résumé-backed skills (Relay, C#/.NET, Python), dropping guessed ones (AWS/Supabase).
- SEO `<title>`, OpenGraph/Twitter, and the OG image updated to match; added Georgia Tech to JSON-LD `alumniOf`.

### Homepage flow
`Hero → Background (career + education) → Writing (blog) → Selected builds`. The `/about` page follows the same system.

## Verification
- Dependencies installed and the dev server compiles and serves the homepage cleanly (`GET / 200`).
- Verified rendering in **light, dark, and mobile** via Playwright screenshots.

## Notes
- The repo currently contains a single blog post; the list renders all `.mdx` in `content/blog/` with no cap, so additional posts appear automatically once committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5wVp6tPTEp2srKJe7wRad

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5wVp6tPTEp2srKJe7wRad)_